### PR TITLE
Hotfix for Issue #52

### DIFF
--- a/packages/dapp/src/components/HighlightModal/Canvas.js
+++ b/packages/dapp/src/components/HighlightModal/Canvas.js
@@ -82,9 +82,11 @@ function HighlightSketch(p5) {
 
   p5.updateWithProps = (props) => {
     if (props.selectedText) {
-      selectedText = props.selectedText;
+      //adding a carraige return in front of text fixes the issue of text overlapping
+      //when it is selected with line breaks
+      //weird p5 issue, I don't know what causes it in the first place
+      selectedText = `\r\n${props.selectedText}`;
       p5.setup();
-      console.log(selectedText.length);
     }
     handleFinishedDrawing = props.handleFinishedDrawing;
   };


### PR DESCRIPTION
Fixes #52 
Text no longer overlaps in p5 when the selection includes linebreaks.

![highlightmodal-hotfix](https://user-images.githubusercontent.com/22751053/171026755-370c1674-1022-4158-b9ab-d46f25f6056b.png)

