### PR TITLE
NFT image flips on click

### DIFF
--- a/packages/dapp/.gitignore
+++ b/packages/dapp/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+secrets.json

--- a/packages/dapp/src/components/SliderModal/NFTShowcase.js
+++ b/packages/dapp/src/components/SliderModal/NFTShowcase.js
@@ -1,13 +1,19 @@
 import { sealedNFTS } from './nft';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { SliderContext } from '../../contexts/Slider';
 
 const NFTShowcase = () => {
   const { state }  = useContext(SliderContext);
+  const [isFlipped, setIsFlipped] = useState(false);
+
+  const handleFlip = () => {
+    setIsFlipped(!isFlipped);
+  }
+
   return (
   <div className="flex-grow flex text-center justify-center  items-center">
-    <div className="flip-card">
-      <div className="flip-card-inner">
+    <div className="flip-card" onClick={handleFlip}>
+      <div className={isFlipped ? "flip-card-inner-flipped" : "flip-card-inner"}>
         <div className="flip-card-front">
           <img src={state.image} alt="Front" />
         </div>

--- a/packages/dapp/src/index.css
+++ b/packages/dapp/src/index.css
@@ -63,8 +63,13 @@ a {
   transform-style: preserve-3d;
 }
 
-/* Do an horizontal flip when you move the mouse over the flip box container */
-.flip-card:hover .flip-card-inner {
+.flip-card-inner-flipped {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 1.2s;
+  transform-style: preserve-3d;
   transform: rotateY(180deg);
 }
 


### PR DESCRIPTION
Change the flip-on-hover effect for the sealed nfts in the slider modal to a click. 
This is (i) more intentional and slower and (ii) will work better on mobile.